### PR TITLE
Fix module

### DIFF
--- a/terraform/airflow-environments.tf
+++ b/terraform/airflow-environments.tf
@@ -1,6 +1,8 @@
 locals {
   security_group_ids = [module.vpc.default_security_group_id]
   subnet_ids         = slice(module.vpc.private_subnets, 0, 2)
+
+  execution_role_basic_policy_arn = aws_iam_policy.execution-role-basic-policy.arn
 }
 
 module "service-foo-staging" {
@@ -10,6 +12,8 @@ module "service-foo-staging" {
 
   security_group_ids = local.security_group_ids
   subnet_ids         = local.subnet_ids
+
+  execution_role_basic_policy_arn = local.execution_role_basic_policy_arn
 
   webserver_access_mode = "PUBLIC_ONLY"
 }
@@ -21,6 +25,8 @@ module "service-foo-production" {
 
   security_group_ids = local.security_group_ids
   subnet_ids         = local.subnet_ids
+
+  execution_role_basic_policy_arn = local.execution_role_basic_policy_arn
 
   webserver_access_mode = "PUBLIC_ONLY"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,3 +35,25 @@ resource "aws_s3_bucket_public_access_block" "example" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+data "aws_iam_policy_document" "execution-role-basic-policy" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetBucket*",
+      "s3:GetObject*",
+      "s3:List*",
+    ]
+    resources = [
+      "arn:aws:s3:::yuyat-apache-airflow-test",
+      "arn:aws:s3:::yuyat-apache-airflow-test/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "execution-role-basic-policy" {
+  name   = "managed-airflow-practice-airflow-executioin-role-basic-policy"
+  policy = data.aws_iam_policy_document.execution-role-basic-policy.json
+}
+

--- a/terraform/modules/airflow-environment/main.tf
+++ b/terraform/modules/airflow-environment/main.tf
@@ -1,7 +1,3 @@
-locals {
-  source_bucket_arn = "arn:aws:s3:::yuyat-apache-airflow-test"
-}
-
 data "aws_iam_policy_document" "airflow-assume-role" {
   version = "2012-10-17"
   statement {
@@ -22,43 +18,22 @@ resource "aws_iam_role" "this" {
   assume_role_policy = data.aws_iam_policy_document.airflow-assume-role.json
 }
 
-data "aws_iam_policy_document" "s3" {
-  version = "2012-10-17"
-  statement {
-    effect = "Allow"
-    actions = [
-      "s3:GetBucket*",
-      "s3:GetObject*",
-      "s3:List*",
-    ]
-    resources = [
-      local.source_bucket_arn,
-      "${local.source_bucket_arn}/*",
-    ]
-  }
-}
-
-resource "aws_iam_policy" "s3" {
-  name   = "managed-airflow-practice-airflow-environment-s3"
-  policy = data.aws_iam_policy_document.s3.json
-}
-
-resource "aws_iam_role_policy_attachment" "s3" {
+resource "aws_iam_role_policy_attachment" "execution-role-basic-policy" {
   role       = aws_iam_role.this.name
-  policy_arn = aws_iam_policy.s3.arn
+  policy_arn = var.execution_role_basic_policy_arn
 }
 
 resource "aws_mwaa_environment" "this" {
+  name               = "managed-airflow-practice-${replace(var.environment_name, "/", "--")}"
   dag_s3_path        = "${var.environment_name}/dags/"
   execution_role_arn = aws_iam_role.this.arn
-  name               = "managed-airflow-practice-${replace(var.environment_name, "/", "--")}"
 
   network_configuration {
     security_group_ids = var.security_group_ids
     subnet_ids         = var.subnet_ids
   }
 
-  source_bucket_arn = local.source_bucket_arn
+  source_bucket_arn = "arn:aws:s3:::yuyat-apache-airflow-test"
 
   webserver_access_mode = var.webserver_access_mode
 }

--- a/terraform/modules/airflow-environment/variables.tf
+++ b/terraform/modules/airflow-environment/variables.tf
@@ -7,6 +7,10 @@ variable "webserver_access_mode" {
   default = "PRIVATE_ONLY"
 }
 
+variable "execution_role_basic_policy_arn" {
+  type = string
+}
+
 variable "security_group_ids" {
   type = list(string)
 }


### PR DESCRIPTION
To fix this error:

```
315 | Error: Error creating IAM policy managed-airflow-practice-airflow-environment-s3: EntityAlreadyExists: A policy called managed-airflow-practice-airflow-environment-s3 already exists. Duplicate names are not allowed.
316 | status code: 409, request id: 881518a3-c980-4b98-be63-a9a54ec58d48
317 |  
318 | on modules/airflow-environment/main.tf line 41, in resource "aws_iam_policy" "s3":
319 | 41: resource "aws_iam_policy" "s3" {
```